### PR TITLE
fix: only deploy unique entity module once

### DIFF
--- a/MUD2/packages/contracts/mud.config.ts
+++ b/MUD2/packages/contracts/mud.config.ts
@@ -135,12 +135,7 @@ export default mudConfig({
     {
       name: 'UniqueEntityModule',
       root: true,
-      args: [resolveTableId('Agent')],
-    },
-    {
-      name: 'UniqueEntityModule',
-      root: true,
-      args: [resolveTableId('Tile')],
+      args: [],
     },
     {
       name: 'KeysWithValueModule',


### PR DESCRIPTION
The `UniqueEntityModule` doesn't require an argument and can only be installed once per world. Once it's installed, you can get a unique entity id with the [`getUniqueEntity()`](https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/uniqueentity/getUniqueEntity.sol) util